### PR TITLE
fix: add graceful error handling for VirusTotal invalid domains

### DIFF
--- a/src/func/domain/parseData.ts
+++ b/src/func/domain/parseData.ts
@@ -47,8 +47,12 @@ export async function parseData(
   } else if (urlScanData.verdicts.overall.malicious === true) {
     verdict = true;
   } else if (
-    virusTotalData.data.attributes.last_analysis_stats.malicious > 0 ||
-    virusTotalData.data.attributes.last_analysis_stats.suspicious > 0
+    virusTotalData &&
+    virusTotalData.data &&
+    virusTotalData.data.attributes &&
+    virusTotalData.data.attributes.last_analysis_stats &&
+    (virusTotalData.data.attributes.last_analysis_stats.malicious > 0 ||
+      virusTotalData.data.attributes.last_analysis_stats.suspicious > 0)
   ) {
     verdict = true;
     // todo: add correct condition for abuseChData

--- a/src/services/AbuseCh.ts
+++ b/src/services/AbuseCh.ts
@@ -26,7 +26,7 @@ export class AbuseChService {
         }
       );
 
-      let sanitizedDomain = await sanitizeDomain(domain);
+      let sanitizedDomain = sanitizeDomain(domain);
       const dbDomain = await getDbDomain(sanitizedDomain);
 
       // Check if the response is JSON before saving to database

--- a/src/services/GoogleSafebrowsing.ts
+++ b/src/services/GoogleSafebrowsing.ts
@@ -19,7 +19,7 @@ export class GoogleSafebrowsingService {
     check: async (domain: string) => {
       // metrics.increment("services.googleSafebrowsing.domain.check");
 
-      const sanitizedDomain = await sanitizeDomain(domain);
+      const sanitizedDomain = sanitizeDomain(domain);
 
       const response = await axios.post(
         `https://safebrowsing.googleapis.com/v4/threatMatches:find?key=${process

--- a/src/services/IpQualityScore.ts
+++ b/src/services/IpQualityScore.ts
@@ -20,7 +20,7 @@ export class IpQualityScoreService {
     check: async (domain: string) => {
       // metrics.increment("services.ipqualityscore.domain.check");
 
-      const sanitizedDomain = await sanitizeDomain(domain);
+      const sanitizedDomain = sanitizeDomain(domain);
 
       const response = await axios.get(
         `https://ipqualityscore.com/api/json/url/${process.env

--- a/src/services/PhishReport.ts
+++ b/src/services/PhishReport.ts
@@ -19,7 +19,7 @@ export class PhishReportService {
     check: async (domain: string) => {
       // metrics.increment("services.phishreport.domain.check");
 
-      const sanitizedDomain = await sanitizeDomain(domain);
+      const sanitizedDomain = sanitizeDomain(domain);
 
       let response = await axios.get(
         `https://phish.report/api/v0/hosting?url=${sanitizedDomain}`,

--- a/src/services/SecurityTrails.ts
+++ b/src/services/SecurityTrails.ts
@@ -19,7 +19,7 @@ export class SecurityTrailsService {
     check: async (domain: string) => {
       // metrics.increment("services.securitytrails.domain.check");
 
-      const sanitizedDomain = await sanitizeDomain(domain);
+      const sanitizedDomain = sanitizeDomain(domain);
 
       const options = {
         method: "GET",

--- a/src/services/SinkingYahts.ts
+++ b/src/services/SinkingYahts.ts
@@ -18,7 +18,7 @@ export class SinkingYahtsService {
      */
     check: async (domain: string) => {
       // metrics.increment("services.sinkingyahts.domain.check");
-      const sanitizedDomain = await sanitizeDomain(domain);
+      const sanitizedDomain = sanitizeDomain(domain);
 
       const response = await axios.get<boolean>(
         `https://phish.sinking.yachts/v2/check/${sanitizedDomain}`,

--- a/src/services/UrlScan.ts
+++ b/src/services/UrlScan.ts
@@ -18,7 +18,7 @@ export class UrlScanService {
      */
     check: async (domain: string) => {
       // metrics.increment("services.urlscan.domain.check");
-      const sanitizedDomain = await sanitizeDomain(domain);
+      const sanitizedDomain = sanitizeDomain(domain);
 
       const checkSearch = await axios.get(
         `https://urlscan.io/api/v1/search/?q=domain:${sanitizedDomain}`,

--- a/src/services/VirusTotal.ts
+++ b/src/services/VirusTotal.ts
@@ -23,7 +23,7 @@ export class VirusTotalService {
         
         // Validate domain before making API call
         try {
-          validateDomain(sanitizedDomain);
+          await validateDomain(sanitizedDomain);
         } catch (error) {
           if (error instanceof DomainValidationError) {
             console.warn(`VirusTotal: Skipping invalid domain "${domain}": ${error.message}`);
@@ -51,7 +51,7 @@ export class VirusTotalService {
         return data;
       } catch (error) {
         // Log the error for transparency, but don't throw to prevent crashes
-        console.warn("VirusTotal API error for domain '%s':", domain, error instanceof Error ? error.message : error);
+        console.warn(`VirusTotal API error for domain "${domain}":`, error instanceof Error ? error.message : error);
         return null;
       }
     },
@@ -68,7 +68,7 @@ export class VirusTotalService {
       
       // Validate domain before making API call
       try {
-        validateDomain(sanitizedDomain);
+        await validateDomain(sanitizedDomain);
       } catch (error) {
         if (error instanceof DomainValidationError) {
           console.warn(`VirusTotal: Skipping report for invalid domain "${domain}": ${error.message}`);

--- a/src/services/VirusTotal.ts
+++ b/src/services/VirusTotal.ts
@@ -51,7 +51,7 @@ export class VirusTotalService {
         return data;
       } catch (error) {
         // Log the error for transparency, but don't throw to prevent crashes
-        console.warn(`VirusTotal API error for domain "${domain}":`, error instanceof Error ? error.message : error);
+        console.warn("VirusTotal API error for domain '%s':", domain, error instanceof Error ? error.message : error);
         return null;
       }
     },

--- a/src/services/Walshy.ts
+++ b/src/services/Walshy.ts
@@ -18,7 +18,7 @@ export class WalshyService {
      */
     check: async (domain: string) => {
       // metrics.increment("services.walshy.domain.check");
-      const sanitizedDomain = await sanitizeDomain(domain);
+      const sanitizedDomain = sanitizeDomain(domain);
 
       const response = await axios.post<{
         badDomain: boolean;
@@ -49,7 +49,7 @@ export class WalshyService {
     report: async (domain: string) => {
       // metrics.increment("services.walshy.domain.report");
 
-      const sanitizedDomain = await sanitizeDomain(domain);
+      const sanitizedDomain = sanitizeDomain(domain);
 
       const response = await axios.post(
         `https://bad-domains.walshy.dev/report`,

--- a/src/utils/sanitizeDomain.ts
+++ b/src/utils/sanitizeDomain.ts
@@ -1,3 +1,5 @@
+import { promises as dns } from 'dns';
+
 const MAX_DOMAIN_LENGTH = 253; // Maximum length of a domain name
 const DOMAIN_REGEX = /^(?!:\/\/)(?:[a-zA-Z0-9-]{1,63}\.)+[a-zA-Z]{2,63}$/;
 
@@ -7,7 +9,7 @@ class DomainValidationError extends Error {
     this.name = "DomainValidationError";
   }
 }
-const validateDomain = (domain: string): boolean => {
+const validateDomain = async (domain: string): Promise<boolean> => {
   // Check domain length
   if (!domain || domain.length > MAX_DOMAIN_LENGTH) {
     throw new DomainValidationError(
@@ -27,6 +29,13 @@ const validateDomain = (domain: string): boolean => {
     domain.includes("/")
   ) {
     throw new DomainValidationError("Domain cannot contain URL components");
+  }
+
+  // Perform DNS lookup to verify domain exists
+  try {
+    await dns.resolve(domain);
+  } catch (error) {
+    throw new DomainValidationError(`Domain does not resolve: ${domain}`);
   }
 
   return true;


### PR DESCRIPTION
## Summary
- Add null checks in parseData.ts to prevent crashes when VirusTotal returns null
- Add domain validation before VirusTotal API calls using existing validateDomain utility
- Enable proper error logging with informative warning messages
- Apply consistent domain validation to both check and report methods

## Test plan
- [ ] Test with valid domains (should work as before)
- [ ] Test with invalid domains (should skip VT call and log warning)
- [ ] Test with unresolvable domains (should handle gracefully)
- [ ] Verify no crashes occur in parseData.ts
- [ ] Check logs for transparency warnings

Fixes #37

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability by adding extra checks to prevent errors when analyzing virus scan data with missing information.
  * Enhanced error handling during domain checks and reports, ensuring invalid domains are safely skipped and users experience fewer disruptions.
* **Chores**
  * Updated domain validation to include DNS resolution for more accurate domain verification.
  * Streamlined domain sanitization by making it synchronous across multiple services, improving performance and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->