### PR TITLE
fix: Handle Quota Usage for APIs

### DIFF
--- a/src/func/domain/domain.ts
+++ b/src/func/domain/domain.ts
@@ -15,6 +15,46 @@ import {
 import { domains } from "src/db/schema";
 import { getDbDomain } from "src/func/db/domain";
 import { db } from "src/utils/db";
+import { warn } from "src/utils/logger";
+
+/**
+ * Helper function to safely call an external API service with quota error handling
+ * @param serviceName - Name of the service for logging
+ * @param serviceCall - Promise function to call the service
+ * @param domain - Domain being checked (for logging)
+ * @returns Service response or null if failed
+ */
+async function safeServiceCall(
+  serviceName: string,
+  serviceCall: () => Promise<any>,
+  domain: string
+): Promise<any> {
+  try {
+    return await serviceCall();
+  } catch (error: any) {
+    // Check for quota/rate limit errors
+    if (
+      error?.response?.status === 429 ||
+      error?.response?.status === 402 ||
+      error?.code === "RATE_LIMITED" ||
+      error?.message?.toLowerCase().includes("quota") ||
+      error?.message?.toLowerCase().includes("rate limit") ||
+      error?.message?.toLowerCase().includes("too many requests")
+    ) {
+      warn(
+        `${serviceName}: API quota/rate limit exceeded for domain "${domain}". Skipping this service check.`
+      );
+    } else {
+      // Log other types of errors with less severity
+      warn(
+        `${serviceName}: API error for domain "${domain}": ${
+          error instanceof Error ? error.message : error
+        }. Skipping this service check.`
+      );
+    }
+    return null;
+  }
+}
 
 /**
  * Check the domain against all the services
@@ -25,17 +65,57 @@ export async function domainCheck(domain: string) {
   const tsStart = Date.now();
   // metrics.increment("functions.domainCheck");
 
-  let walshyData = await walshyService.domain.check(domain);
-  let ipQualityScoreData = await ipQualityScoreService.domain.check(domain);
-  let googleSafebrowsingData =
-    await googleSafebrowsingService.domain.check(domain);
-  let sinkingYahtsData = await sinkingYahtsService.domain.check(domain);
-  let virusTotalData = await virusTotalService.domain.check(domain);
-  let phishObserverData = await phishObserverService.domain.check(domain);
-  let urlScanData = await urlScanService.domain.check(domain);
-  let securitytrailsData = await securityTrailsService.domain.check(domain);
-  let phishreportData = await phishReportService.domain.check(domain);
-  let abuseChData = await abuseChService.domain.check(domain);
+  // Use graceful error handling for each service call
+  let walshyData = await safeServiceCall(
+    "Walshy",
+    () => walshyService.domain.check(domain),
+    domain
+  );
+  let ipQualityScoreData = await safeServiceCall(
+    "IpQualityScore",
+    () => ipQualityScoreService.domain.check(domain),
+    domain
+  );
+  let googleSafebrowsingData = await safeServiceCall(
+    "GoogleSafebrowsing",
+    () => googleSafebrowsingService.domain.check(domain),
+    domain
+  );
+  let sinkingYahtsData = await safeServiceCall(
+    "SinkingYahts",  
+    () => sinkingYahtsService.domain.check(domain),
+    domain
+  );
+  let virusTotalData = await safeServiceCall(
+    "VirusTotal",
+    () => virusTotalService.domain.check(domain),
+    domain
+  );
+  let phishObserverData = await safeServiceCall(
+    "PhishObserver",
+    () => phishObserverService.domain.check(domain),
+    domain
+  );
+  let urlScanData = await safeServiceCall(
+    "UrlScan",
+    () => urlScanService.domain.check(domain),
+    domain
+  );
+  let securitytrailsData = await safeServiceCall(
+    "SecurityTrails",
+    () => securityTrailsService.domain.check(domain),
+    domain
+  );
+  let phishreportData = await safeServiceCall(
+    "PhishReport",
+    () => phishReportService.domain.check(domain),
+    domain
+  );
+  let abuseChData = await safeServiceCall(
+    "AbuseCh",
+    () => abuseChService.domain.check(domain),
+    domain
+  );
 
   let dbDomain = await getDbDomain(domain);
 

--- a/src/func/domain/parseData.ts
+++ b/src/func/domain/parseData.ts
@@ -29,24 +29,41 @@ export async function parseData(
   const tsStart = Date.now();
   // metrics.increment("functions.domain.parseData");
 
-  let verdict: boolean;
+  let verdict: boolean = false;
 
-  if (walshyData.badDomain) {
+  // Check Walshy data - handle null/undefined gracefully
+  if (walshyData && walshyData.badDomain) {
     verdict = true;
-  } else if (Object.keys(googleSafebrowsingData).length !== 0) {
+  }
+  // Check Google Safe Browsing data - handle null/undefined gracefully
+  else if (googleSafebrowsingData && Object.keys(googleSafebrowsingData).length !== 0) {
     verdict = true;
-  } else if (
-    ipQualityScoreData.unsafe ||
-    ipQualityScoreData.spam ||
-    ipQualityScoreData.phishing ||
-    ipQualityScoreData.malware
+  }
+  // Check IpQualityScore data - handle null/undefined gracefully
+  else if (
+    ipQualityScoreData &&
+    (ipQualityScoreData.unsafe ||
+      ipQualityScoreData.spam ||
+      ipQualityScoreData.phishing ||
+      ipQualityScoreData.malware)
   ) {
     verdict = true;
-  } else if (sinkingYahtsData) {
+  }
+  // Check SinkingYahts data - handle null/undefined gracefully
+  else if (sinkingYahtsData) {
     verdict = true;
-  } else if (urlScanData.verdicts.overall.malicious === true) {
+  }
+  // Check UrlScan data - handle null/undefined gracefully
+  else if (
+    urlScanData &&
+    urlScanData.verdicts &&
+    urlScanData.verdicts.overall &&
+    urlScanData.verdicts.overall.malicious === true
+  ) {
     verdict = true;
-  } else if (
+  }
+  // Check VirusTotal data - already has good null checking
+  else if (
     virusTotalData &&
     virusTotalData.data &&
     virusTotalData.data.attributes &&
@@ -55,11 +72,11 @@ export async function parseData(
       virusTotalData.data.attributes.last_analysis_stats.suspicious > 0)
   ) {
     verdict = true;
-    // todo: add correct condition for abuseChData
-    // } else if (abuseChData.query_status === "ok" && abuseChData.) {
-  } else {
-    verdict = false;
   }
+  // TODO: add correct condition for abuseChData when needed
+  // else if (abuseChData && abuseChData.query_status === "ok" && ...) {
+  //   verdict = true;
+  // }
 
   return verdict;
 }


### PR DESCRIPTION
Fixes #27

Implements graceful error handling for API quota limits to prevent application crashes.

## Changes
- Add `safeServiceCall()` wrapper for all external API services
- Detect and handle quota/rate limit errors (HTTP 429, 402, etc.)
- Log warnings instead of crashing when APIs fail
- Add null/undefined checks in parseData to prevent crashes
- Ensure graceful degradation when services are unavailable

## Testing
The app now:
- ✅ No longer crashes when API quotas are exceeded
- ✅ Gracefully skips failed requests with warning logs
- ✅ Continues domain checking with available services
- ✅ Provides better observability through logging

Generated with [Claude Code](https://claude.ai/code)